### PR TITLE
Fix hardcoded Linux CUDA path in common.py

### DIFF
--- a/cumm/common.py
+++ b/cumm/common.py
@@ -278,7 +278,7 @@ def _get_cuda_include_lib():
             except:
                 pass 
 
-            linux_cuda_root = Path("/usr/local/cuda")
+            linux_cuda_root = Path(os.getenv("CUDA_HOME", "/usr/local/cuda"))
             include = linux_cuda_root / f"include"
             lib64 = linux_cuda_root / f"lib64"
             assert linux_cuda_root.exists(), f"can't find cuda in {linux_cuda_root} install via cuda installer or conda first."


### PR DESCRIPTION
This PR fix the hardcoded path to the CUDA includes.

This allows the user to set it's prefered path to CUDA, instead of relying on default installation parameters.